### PR TITLE
replace `[ $1 = 𝑥 ]` with `case` statement (fix #15)

### DIFF
--- a/bin/git-default-branch
+++ b/bin/git-default-branch
@@ -9,36 +9,43 @@
 #
 # return the name of a repository’s default branch
 git_default_branch() {
-  [ "${1}" = -v ] || [ "${1}" = --verbose ] && set -x
+  case "${1-}" in
+  -v | --verbose)
+    set -x
+    shift
+    ;;
 
-  # check if there’s a `remote` with a default branch and
-  # if so, then use that name for `default_branch`
-  # https://stackoverflow.com/a/44750379
-  if git symbolic-ref refs/remotes/origin/HEAD >/dev/null 2>&1; then
-    default_branch=$(git symbolic-ref refs/remotes/origin/HEAD |
-      sed 's@^refs/remotes/origin/@@')
+  *)
+    # check if there’s a `remote` with a default branch and
+    # if so, then use that name for `default_branch`
+    # https://stackoverflow.com/a/44750379
+    if git symbolic-ref refs/remotes/origin/HEAD >/dev/null 2>&1; then
+      default_branch=$(git symbolic-ref refs/remotes/origin/HEAD |
+        sed 's@^refs/remotes/origin/@@')
 
-  # check for `main`, which, if it exists, is most likely to be default
-  elif [ -n "$(git branch --list main)" ]; then
-    default_branch=main
+    # check for `main`, which, if it exists, is most likely to be default
+    elif [ -n "$(git branch --list main)" ]; then
+      default_branch=main
 
-  # check for a branch called `master`
-  elif [ -n "$(git branch --list master)" ]; then
-    default_branch=master
+    # check for a branch called `master`
+    elif [ -n "$(git branch --list master)" ]; then
+      default_branch=master
 
-  else
-    # fail with explanation
-    printf 'unable to detect a \x60main\x60, \x60master\x60, or default '
-    printf 'branch in this repository\n'
-    return 2
-  fi
+    else
+      # fail with explanation
+      printf 'unable to detect a \x60main\x60, \x60master\x60, or default '
+      printf 'branch in this repository\n'
+      return 2
+    fi
 
-  # return the result
-  printf '%s\n' "${default_branch}"
-  unset default_branch
+    # return the result
+    printf '%s\n' "${default_branch}"
+    unset default_branch
 
-  # undo `set -x` silently
-  { set +x; } 2>/dev/null
+    # undo `set -x` silently
+    { set +x; } 2>/dev/null
+    ;;
+  esac
 }
 
 git_default_branch "${@}"


### PR DESCRIPTION
now:
```sh
[ "${1}" = -v ] || [ "${1}" = --verbose ]
```

---
if we fix #15:
```sh
case "${1-}" in
  -v | --verbose)
```
