### PR TITLE
remove `git.io` links (fix #26)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,6 @@
 ---
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://git.io/help-dependabot-configuration
 
 version: 2
 updates:


### PR DESCRIPTION
@GitHub ends 11 years of serving `git.io` redirections on 2022-04-29[^1] after providing 3 days warning. This Pull Request™ removes affected content to fix #26.

[^1]: [github.blog/changelog/2022-04-25-git-io-deprecation](https://github.blog/changelog/2022-04-25-git-io-deprecation/)