### PR TITLE
check also for `mainline`, `default` branches

### DIFF
--- a/bin/git-default-branch
+++ b/bin/git-default-branch
@@ -42,6 +42,13 @@ git_default_branch() {
     elif test -n "$(command git branch --list -- 'HEAD')"; then
       default_branch='HEAD'
 
+    # check for branches called `mainline`, `default`
+    # https://github.com/progit/progit2/commit/3680ec7865
+    elif test -n "$(command git branch --list -- 'mainline')"; then
+      default_branch='mainline'
+    elif test -n "$(command git branch --list -- 'default')"; then
+      default_branch='default'
+
     else
       # fail with explanation
       printf 'unable to detect a\n'


### PR DESCRIPTION
both `mainline` and `default` are also common enough default branch names to be published in _Pro Git_ and should be searched for before failure.

https://github.com/progit/progit2/commit/3680ec7865 via https://github.com/ohmyzsh/ohmyzsh/commit/280c99dae6